### PR TITLE
Update team name text

### DIFF
--- a/2021-AUG/src/TeamCard.tsx
+++ b/2021-AUG/src/TeamCard.tsx
@@ -41,7 +41,7 @@ const TeamCard = (props: Props) => {
           title={name}
         />
         <CardContent>
-          <Typography gutterBottom variant="h5" component="h2">
+          <Typography gutterBottom component="h2">
             {name}
           </Typography>
           <Box maxHeight="58px" textOverflow="ellipsis" overflow="auto">

--- a/2021-AUG/src/TeamCard.tsx
+++ b/2021-AUG/src/TeamCard.tsx
@@ -19,6 +19,9 @@ const useStyles = makeStyles({
     height: 150,
     objectFit: "scale-down",
   },
+  bold: {
+    fontWeight: "bold",
+  }
 });
 
 type Props = {
@@ -41,7 +44,7 @@ const TeamCard = (props: Props) => {
           title={name}
         />
         <CardContent>
-          <Typography gutterBottom component="h2">
+          <Typography gutterBottom className={classes.bold} component="h2">
             {name}
           </Typography>
           <Box maxHeight="58px" textOverflow="ellipsis" overflow="auto">


### PR DESCRIPTION
I was wondering about the cards having different sizes. It seemed one team name is longer than other team names and resulted in expanding the card height.
![Screen Shot 2021-07-27 at 8 16 00 PM](https://user-images.githubusercontent.com/60810343/127258969-ffaee041-3b82-453a-af17-962902504458.png)

I made a few changes so that all cards have the same size. Also, reduced the size of the team names.
![Screen Shot 2021-07-27 at 8 21 51 PM](https://user-images.githubusercontent.com/60810343/127259125-1ff06a58-1494-4c65-8928-e9799e07f204.png)
